### PR TITLE
Unify the usage of "serverURL" and token options

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ The library can be used by NodeJS applications, tools, and other automations to 
 You can install the SDK using npm
 
 ```
-npm install  @1password/connect
+npm install @1password/connect
 ```
 
 or using Yarn
@@ -32,7 +32,7 @@ import { OnePasswordConnect, ItemBuilder } from "@1password/connect";
 
 // Create new connector with HTTP Pooling
 const op = OnePasswordConnect({
-	serverUrl: "http://localhost:8000",
+	serverURL: "http://localhost:8000",
 	token: "my-token",
 	keepAlive: true,
 });

--- a/__test__/adapter.test.ts
+++ b/__test__/adapter.test.ts
@@ -8,9 +8,9 @@ jest.mock("../src/lib/client", () => ({
         HTTPClient: jest.fn().mockImplementation(() => ({request: mockedRequest})),
     }));
 
-test("Assert Token and BaseURL are required", () => {
+test("Assert Token and Server URL are required", () => {
     expect(() => new RequestAdapter(new HTTPClient(), {serverURL: undefined, token: undefined}))
-        .toThrowError("ServerURL and Token are required.");
+        .toThrowError("Options serverURL and token are required.");
 });
 
 describe("Assert Adapter delegates calls to Client", () => {

--- a/src/lib/op-connect.ts
+++ b/src/lib/op-connect.ts
@@ -27,7 +27,7 @@ export const newConnectClient = (opts: OPConfig): OPConnect => {
     }
 
     if (!opts.serverURL || !opts.token) {
-        throw new Error("BaseURL and Token are required.");
+        throw new Error("Options serverUrl and token are required.");
     }
 
     return new OPConnect(opts);

--- a/src/lib/op-connect.ts
+++ b/src/lib/op-connect.ts
@@ -27,7 +27,7 @@ export const newConnectClient = (opts: OPConfig): OPConnect => {
     }
 
     if (!opts.serverURL || !opts.token) {
-        throw new Error("Options serverUrl and token are required.");
+        throw new Error("Options serverURL and token are required.");
     }
 
     return new OPConnect(opts);

--- a/src/lib/requests.ts
+++ b/src/lib/requests.ts
@@ -12,7 +12,7 @@ export class RequestAdapter {
 
     public constructor(client, opts: RequestAdapterOptions) {
         if (!opts.serverURL || !opts.token) {
-            throw TypeError("ServerURL and Token are required.");
+            throw TypeError("Options serverURL and token are required.");
         }
 
         this.baseURL = new URL(opts.serverURL);


### PR DESCRIPTION
This PR is a small fix for the parameter usage, unifying `serverUrl`, `BaseURL`, `ServerURL`, `token` and `Token` to `serverURL`. Using the current instructions (on JavaScript files, TypeScript catches it), users will run into a bit of an confusing error `BaseURL and token are required` if the user copies the 

```js
const op = OnePasswordConnect({
	serverUrl: "http://localhost:8000",
	token: "my-token",
	keepAlive: true,
});
```

example from the README.md