### PR TITLE
Remove unused code created by the openapi-generator.

### DIFF
--- a/src/model/errorResponse.ts
+++ b/src/model/errorResponse.ts
@@ -10,8 +10,6 @@
  * Do not edit the class manually.
  */
 
-import { RequestFile } from './models';
-
 export class ErrorResponse {
     /**
     * HTTP Status Code

--- a/src/model/fullItem.ts
+++ b/src/model/fullItem.ts
@@ -10,7 +10,6 @@
  * Do not edit the class manually.
  */
 
-import { RequestFile } from './models';
 import { FullItemAllOf } from './fullItemAllOf';
 import { FullItemAllOfFields } from './fullItemAllOfFields';
 import { FullItemAllOfSections } from './fullItemAllOfSections';

--- a/src/model/fullItemAllOf.ts
+++ b/src/model/fullItemAllOf.ts
@@ -10,7 +10,6 @@
  * Do not edit the class manually.
  */
 
-import { RequestFile } from './models';
 import { FullItemAllOfFields } from './fullItemAllOfFields';
 import { FullItemAllOfSections } from './fullItemAllOfSections';
 

--- a/src/model/fullItemAllOfFields.ts
+++ b/src/model/fullItemAllOfFields.ts
@@ -10,7 +10,6 @@
  * Do not edit the class manually.
  */
 
-import { RequestFile } from './models';
 import { FullItemAllOfSection } from './fullItemAllOfSection';
 import { GeneratorRecipe } from './generatorRecipe';
 

--- a/src/model/fullItemAllOfSection.ts
+++ b/src/model/fullItemAllOfSection.ts
@@ -10,8 +10,6 @@
  * Do not edit the class manually.
  */
 
-import { RequestFile } from './models';
-
 export class FullItemAllOfSection {
     'id'?: string;
 

--- a/src/model/fullItemAllOfSections.ts
+++ b/src/model/fullItemAllOfSections.ts
@@ -10,8 +10,6 @@
  * Do not edit the class manually.
  */
 
-import { RequestFile } from './models';
-
 export class FullItemAllOfSections {
     'id'?: string;
     'label'?: string;

--- a/src/model/generatorRecipe.ts
+++ b/src/model/generatorRecipe.ts
@@ -10,8 +10,6 @@
  * Do not edit the class manually.
  */
 
-import { RequestFile } from './models';
-
 /**
 * The recipe is used in conjunction with the \"generate\" property to set the character set used to generate a new secure value
 */

--- a/src/model/item.ts
+++ b/src/model/item.ts
@@ -10,7 +10,6 @@
  * Do not edit the class manually.
  */
 
-import { RequestFile } from './models';
 import { ItemUrls } from './itemUrls';
 import { ItemVault } from './itemVault';
 

--- a/src/model/itemUrls.ts
+++ b/src/model/itemUrls.ts
@@ -10,8 +10,6 @@
  * Do not edit the class manually.
  */
 
-import { RequestFile } from './models';
-
 export class ItemUrls {
     'primary'?: boolean;
     'href': string;

--- a/src/model/itemVault.ts
+++ b/src/model/itemVault.ts
@@ -10,7 +10,6 @@
  * Do not edit the class manually.
  */
 
-import { RequestFile } from './models';
 
 export class ItemVault {
     'id': string;

--- a/src/model/models.ts
+++ b/src/model/models.ts
@@ -1,5 +1,3 @@
-import localVarRequest from 'request';
-
 export * from './errorResponse';
 export * from './fullItem';
 export * from './fullItemAllOf';
@@ -11,19 +9,6 @@ export * from './item';
 export * from './itemUrls';
 export * from './itemVault';
 export * from './vault';
-
-import * as fs from 'fs';
-
-export interface RequestDetailedFile {
-    value: Buffer;
-    options?: {
-        filename?: string;
-        contentType?: string;
-    }
-}
-
-export type RequestFile = string | Buffer | fs.ReadStream | RequestDetailedFile;
-
 
 import { ErrorResponse } from './errorResponse';
 import { FullItem } from './fullItem';
@@ -37,28 +22,27 @@ import { ItemUrls } from './itemUrls';
 import { ItemVault } from './itemVault';
 import { Vault } from './vault';
 
-/* tslint:disable:no-unused-variable */
 let primitives = [
-                    "string",
-                    "boolean",
-                    "double",
-                    "integer",
-                    "long",
-                    "float",
-                    "number",
-                    "any"
-                 ];
+    "string",
+    "boolean",
+    "double",
+    "integer",
+    "long",
+    "float",
+    "number",
+    "any"
+];
 
-let enumsMap: {[index: string]: any} = {
-        "FullItem.CategoryEnum": FullItem.CategoryEnum,
-        "FullItemAllOfFields.TypeEnum": FullItemAllOfFields.TypeEnum,
-        "FullItemAllOfFields.PurposeEnum": FullItemAllOfFields.PurposeEnum,
-        "GeneratorRecipe.CharacterSetsEnum": GeneratorRecipe.CharacterSetsEnum,
-        "Item.CategoryEnum": Item.CategoryEnum,
-        "Vault.TypeEnum": Vault.TypeEnum,
+let enumsMap: { [index: string]: any } = {
+    "FullItem.CategoryEnum": FullItem.CategoryEnum,
+    "FullItemAllOfFields.TypeEnum": FullItemAllOfFields.TypeEnum,
+    "FullItemAllOfFields.PurposeEnum": FullItemAllOfFields.PurposeEnum,
+    "GeneratorRecipe.CharacterSetsEnum": GeneratorRecipe.CharacterSetsEnum,
+    "Item.CategoryEnum": Item.CategoryEnum,
+    "Vault.TypeEnum": Vault.TypeEnum,
 }
 
-let typeMap: {[index: string]: any} = {
+let typeMap: { [index: string]: any } = {
     "ErrorResponse": ErrorResponse,
     "FullItem": FullItem,
     "FullItemAllOf": FullItemAllOf,
@@ -96,7 +80,7 @@ export class ObjectSerializer {
             } else {
                 if (data[discriminatorProperty]) {
                     var discriminatorType = data[discriminatorProperty];
-                    if(typeMap[discriminatorType]){
+                    if (typeMap[discriminatorType]) {
                         return discriminatorType; // use the type given in the discriminator
                     } else {
                         return expectedType; // discriminator did not map to a type
@@ -137,7 +121,7 @@ export class ObjectSerializer {
 
             // get the map for the correct type.
             let attributeTypes = typeMap[type].getAttributeTypeMap();
-            let instance: {[index: string]: any} = {};
+            let instance: { [index: string]: any } = {};
             for (let index in attributeTypes) {
                 let attributeType = attributeTypes[index];
                 instance[attributeType.baseName] = ObjectSerializer.serialize(data[attributeType.name], attributeType.type);
@@ -182,77 +166,3 @@ export class ObjectSerializer {
         }
     }
 }
-
-export interface Authentication {
-    /**
-    * Apply authentication settings to header and query params.
-    */
-    applyToRequest(requestOptions: localVarRequest.Options): Promise<void> | void;
-}
-
-export class HttpBasicAuth implements Authentication {
-    public username: string = '';
-    public password: string = '';
-
-    applyToRequest(requestOptions: localVarRequest.Options): void {
-        requestOptions.auth = {
-            username: this.username, password: this.password
-        }
-    }
-}
-
-export class HttpBearerAuth implements Authentication {
-    public accessToken: string | (() => string) = '';
-
-    applyToRequest(requestOptions: localVarRequest.Options): void {
-        if (requestOptions && requestOptions.headers) {
-            const accessToken = typeof this.accessToken === 'function'
-                            ? this.accessToken()
-                            : this.accessToken;
-            requestOptions.headers["Authorization"] = "Bearer " + accessToken;
-        }
-    }
-}
-
-export class ApiKeyAuth implements Authentication {
-    public apiKey: string = '';
-
-    constructor(private location: string, private paramName: string) {
-    }
-
-    applyToRequest(requestOptions: localVarRequest.Options): void {
-        if (this.location == "query") {
-            (<any>requestOptions.qs)[this.paramName] = this.apiKey;
-        } else if (this.location == "header" && requestOptions && requestOptions.headers) {
-            requestOptions.headers[this.paramName] = this.apiKey;
-        } else if (this.location == 'cookie' && requestOptions && requestOptions.headers) {
-            if (requestOptions.headers['Cookie']) {
-                requestOptions.headers['Cookie'] += '; ' + this.paramName + '=' + encodeURIComponent(this.apiKey);
-            }
-            else {
-                requestOptions.headers['Cookie'] = this.paramName + '=' + encodeURIComponent(this.apiKey);
-            }
-        }
-    }
-}
-
-export class OAuth implements Authentication {
-    public accessToken: string = '';
-
-    applyToRequest(requestOptions: localVarRequest.Options): void {
-        if (requestOptions && requestOptions.headers) {
-            requestOptions.headers["Authorization"] = "Bearer " + this.accessToken;
-        }
-    }
-}
-
-export class VoidAuth implements Authentication {
-    public username: string = '';
-    public password: string = '';
-
-    applyToRequest(_: localVarRequest.Options): void {
-        // Do nothing
-    }
-}
-
-export type Interceptor = (requestOptions: localVarRequest.Options) => (Promise<void> | void);

--- a/src/model/vault.ts
+++ b/src/model/vault.ts
@@ -10,8 +10,6 @@
  * Do not edit the class manually.
  */
 
-import { RequestFile } from './models';
-
 export class Vault {
     'id'?: string;
     'name'?: string;


### PR DESCRIPTION
Removes unused imports and classes from the generated models. Removing this code is a pre-requisite for updating our packages because the generated code imported a definition from the `request` library.

We originally used `openapi-generator-cli` to create model classes from our OpenAPI 3.0 spec. The generator inserted extra classes for Authentication that we do not use anywhere in the code and we can safely remove those from the codebase.

