### PR TITLE
README updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ let vault = await op.getVault({vault_id});
 const myVaultId = {vault_uuid};
 
 // Create an Item
-const newItem = ItemBuilder()
+const newItem = new ItemBuilder()
 	.setVault(myVaultId)
     .setCategory("LOGIN")
 	.addField({
@@ -124,7 +124,7 @@ The 1Password Connect JS client uses the [`debug`](https://www.npmjs.com/package
 All log messages are defined under the `opconnect` namespace. To print log statements, include the `opconnect` namespace when defining the `DEBUG` environment variable:
 
 ```
-DEBUG=opconnect
+DEBUG=opconnect:*
 ```
 
 ## Development


### PR DESCRIPTION
Fixes
- The ItemBuilder example needed to have the `new` keyword. 
- The logging section needs and updated example to have `DEBUG=opconnect:*` otherwise debug does not log the requests or the builder logs