### PR TITLE
Fix create item example in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ const newItem = new ItemBuilder()
 	})
 	.build();
 
-const createdItem = await op.createItem(newItem);
+const createdItem = await op.createItem(myVaultId, newItem);
 
 // Get an Item
 const item = await op.getItem(myVaultId, {item_uuid});


### PR DESCRIPTION
The `createItem` function has the wrong signature in the README example.

Relates: #29 