### PR TITLE
Add a release pipeline

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,38 @@
+name: Release SDK if needed
+
+on:
+  pull_request:
+    branches: main
+    types: closed
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    if: github.event.pull_request.merged == true && contains(github.event.pull_request.head.ref, 'release/')
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+      - name: Setup Node
+        uses: actions/setup-node@v2
+        with:
+          node-version: '12.x'
+          registry-url: 'https://registry.npmjs.org'
+      - run: npm install
+      - name: Publish to npm
+        run: npm publish
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+      - name: Create Release tag
+        id: create-tag
+        run: |
+          release_tag=$(echo ${{ github.event.pull_request.head.ref }} | cut -d "/" -f2)
+          echo "::set-output name=release-tag::$release_tag"
+      - name: Make new release
+        uses: ncipollo/release-action@v1
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          tag: ${{ steps.create-tag.outputs.release-tag }}
+          commit: main
+          body: ${{ github.event.pull_request.body }}


### PR DESCRIPTION
This automates the publishing to npm, as well as the release on GitHub.

The following steps will be performed:
- publish the package on `npm`
- create a release tag
- make a release on GitHub with the description from the release PR