### PR TITLE
Fix TypeEnum.Totp to point at correct type value, add TypeEnum.Otp

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
   * A user-friendly description of a new feature. {issue-number}
 
 ## Fixes
- * A user-friendly description of a fix. {issue-number}
+ * The field `TypeEnum.Totp` now points to the correct value.  {#40}
 
 ## Security
  * A user-friendly description of a security fix. {issue-number}

--- a/src/model/fullItemAllOfFields.ts
+++ b/src/model/fullItemAllOfFields.ts
@@ -93,7 +93,9 @@ export namespace FullItemAllOfFields {
         Email = <any> 'EMAIL',
         Concealed = <any> 'CONCEALED',
         Url = <any> 'URL',
-        Totp = <any> 'TOTP',
+        /** @deprecated use {@link TypeEnum.Otp} instead. */
+        Totp = <any> 'OTP',
+        Otp = <any> 'OTP',
         Date = <any> 'DATE',
         MonthYear = <any> 'MONTH_YEAR',
         Menu = <any> 'MENU'


### PR DESCRIPTION
# Summary

This changelist fixes an issue originating in the OpenAPI spec for 1Password Connect. We originally generated the model classes from the API spec, but the spec incorrectly listed `TOTP` as a valid field type. The correct field type is `OTP`.

**The Fix**

I changed the value `FullItemAllOfFields.TypeEnum.Totp` points to so it now sends `otp` to the server when creating an item with an OTP field. This creates some confusion between the Enum label and its actual value. I decided to soft-deprecate the `TypeEnum.Totp` enum and add a `TypeEnum.Otp` enum to preserve backwards compatibility.

Both enums point to the same value, and in the future I would like to see `TypeEnum.Totp` removed entirely.
