### PR TITLE
Issue/63/get file by

### DIFF
--- a/__test__/mocks/api.mock.ts
+++ b/__test__/mocks/api.mock.ts
@@ -3,6 +3,7 @@ import nock from "nock";
 export class ApiMock {
     static VAULT_ID = 'llriqid2uq6ucvxpe21vaultid';
     static ITEM_ID =  "llriqid2uq6ucvxpe2n1itemid";
+    static FILE_ID =  "llriqid2uq6ucvxpe2n1fileid";
 
     public nock: any;
     private scope: nock.Scope;
@@ -14,6 +15,7 @@ export class ApiMock {
         this.pathBuilder = new PathBuilder({
             vaultId: ApiMock.VAULT_ID,
             itemId: ApiMock.ITEM_ID,
+            fileId: ApiMock.FILE_ID,
         })
     }
 
@@ -21,11 +23,11 @@ export class ApiMock {
         return this.scope.get(this.pathBuilder.itemById(itemId, vaultId));
     }
 
-    listItemsByTitle(title: string, itemId?: string, vaultId?: string): nock.Interceptor {
+    listItemsByTitle(title: string, vaultId?: string): nock.Interceptor {
         return this.scope.get(this.pathBuilder.items(vaultId))
-                .query({
-                    filter: `title eq "${title}"`,
-                });
+            .query({
+                filter: `title eq "${title}"`,
+            });
     }
 
     deleteItemById(itemId?: string, vaultId?: string): nock.Interceptor {
@@ -33,24 +35,37 @@ export class ApiMock {
     }
 
     listItemFiles(vaultId?: string, itemId?: string): nock.Interceptor {
-        return this.scope.get(this.pathBuilder.listFiles(vaultId, itemId));
+        return this.scope.get(this.pathBuilder.files(vaultId, itemId));
     }
 
-    listItemsByTitleContains(title: string, itemId?: string, vaultId?: string): nock.Interceptor {
+    listItemsByTitleContains(title: string, vaultId?: string): nock.Interceptor {
         return this.scope.get(this.pathBuilder.items(vaultId))
-                .query({
-                    filter: `title co "${title}"`,
-                });
+            .query({
+                filter: `title co "${title}"`,
+            });
+    }
+
+    listVaultsByTitle(title: string): nock.Interceptor {
+        return this.scope.get(this.pathBuilder.vaults())
+            .query({
+                filter: `title eq "${title}"`,
+            });
+    }
+
+    getFileById(fileId?: string, vaultId?: string, itemId?: string): nock.Interceptor {
+        return this.scope.get(this.pathBuilder.fileById(vaultId, itemId, fileId));
     }
 }
 
 class PathBuilder {
     private readonly VAULT_ID: string;
     private readonly ITEM_ID: string;
+    private readonly FILE_ID: string;
 
     constructor(options: Options) {
         this.VAULT_ID = options.vaultId;
         this.ITEM_ID = options.itemId;
+        this.FILE_ID = options.fileId;
     }
 
     vaults(): string {
@@ -69,12 +84,17 @@ class PathBuilder {
         return `${this.items(vaultId)}${itemId || this.ITEM_ID}`;
     }
 
-    listFiles(vaultId?: string, itemId?: string): string {
-        return `${this.items(vaultId)}${itemId || this.ITEM_ID}/files`;
+    files(vaultId?: string, itemId?: string): string {
+        return `${this.itemById(itemId, vaultId)}/files/`;
+    }
+
+    fileById(fileId?: string, vaultId?: string, itemId?: string): string {
+        return `${this.files(vaultId, itemId)}${fileId || this.FILE_ID}`;
     }
 }
 
 interface Options {
     vaultId: string;
     itemId: string;
+    fileId: string;
 }

--- a/__test__/op-connect.test.ts
+++ b/__test__/op-connect.test.ts
@@ -479,6 +479,11 @@ describe("Test OnePasswordConnect CRUD", () => {
     });
 
     describe("get file by id", () => {
+        test.each(["", null, undefined])
+            ("should throw error if %s provides as file id", async (fileId) => {
+                await expect(() => op.getFileById(vaultTitle, itemTitle, fileId)).rejects.toThrowError(new Error(ErrorMessageFactory.noFileIdProvided()));
+            });
+
         test("should throw error if invalid vault id provided", async () => {
             apiMock.listVaultsByTitle(vaultTitle).replyWithError("something went wrong");
 

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -9,6 +9,7 @@ export const ERROR_MESSAGE = {
     PROVIDE_ITEM_NAME_OR_ID: "Please provide either the item name or its ID.",
 
     NO_OTP_FOR_THE_ITEM: "No OTP found for the Item",
+    NO_FILE_ID_PROVIDED: "No fileId provided",
 }
 
 export const ID_PREFIX = {

--- a/src/lib/op-connect.ts
+++ b/src/lib/op-connect.ts
@@ -2,7 +2,7 @@ import { FullItem } from "../model/fullItem";
 import { Item as SimpleItem } from "../model/item";
 import { Vault } from "../model/vault";
 import { ItemFile } from "../model/itemFile";
-import { Items, Vaults } from "./resources";
+import { Files, Items, Vaults } from "./resources";
 
 import { HTTPClient, IRequestClient } from "./client";
 
@@ -38,6 +38,7 @@ export const newConnectClient = (opts: OPConfig): OPConnect => {
 class OPConnect {
     private vaults: Vaults;
     private items: Items;
+    private files: Files;
 
     private readonly httpAdapter: RequestAdapter;
 
@@ -49,6 +50,7 @@ class OPConnect {
 
         this.vaults = new Vaults(this.httpAdapter);
         this.items = new Items(this.httpAdapter);
+        this.files = new Files(this.httpAdapter, this.vaults, this.items);
     }
 
     /**
@@ -146,7 +148,7 @@ class OPConnect {
         titleSearchStr: string,
     ): Promise<FullItem[]> {
         return this.items.listItemsByTitleContains(vaultId, titleSearchStr);
-    } 
+    }
 
     /**
      * Get details about a specific Item in a Vault.
@@ -288,5 +290,17 @@ class OPConnect {
      */
     public async listFiles(vaultId: string, itemId: string): Promise<ItemFile[]> {
         return this.items.listFiles(vaultId, itemId);
+    }
+
+    /**
+     * Get an Item's specific File with a matching ID value.
+     *
+     * @param {string} vaultQuery - the Vaults's title or ID
+     * @param {string} itemQuery - the Item's title or ID
+     * @param {string} fileId - File's ID
+     * @returns {Promise<ItemFile>}
+     */
+    public async getFileById(vaultQuery: string, itemQuery: string, fileId: string): Promise<ItemFile> {
+        return this.files.getById(vaultQuery, itemQuery, fileId);
     }
 }

--- a/src/lib/op-connect.ts
+++ b/src/lib/op-connect.ts
@@ -284,12 +284,12 @@ class OPConnect {
     /**
      * Get a list of files an Item contains.
      *
-     * @param {string} vaultId
-     * @param {string} itemId
+     * @param {string} vaultQuery - the Vaults's title or ID
+     * @param {string} itemQuery - the Item's title or ID
      * @returns {Promise<ItemFile[]>}
      */
-    public async listFiles(vaultId: string, itemId: string): Promise<ItemFile[]> {
-        return this.items.listFiles(vaultId, itemId);
+    public async listFiles(vaultQuery: string, itemQuery: string): Promise<ItemFile[]> {
+        return this.files.listFiles(vaultQuery, itemQuery);
     }
 
     /**

--- a/src/lib/resources.ts
+++ b/src/lib/resources.ts
@@ -354,6 +354,10 @@ export class Files extends OPResource {
     }
 
     private async generateSingleFileUrl(vaultQuery: string, itemQuery: string, fileId: string): Promise<string> {
+        if (!fileId) {
+            throw new Error(ErrorMessageFactory.noFileIdProvided());
+        }
+
         let url = await this.generateFilesUrl(vaultQuery, itemQuery);
         url += fileId;
 

--- a/src/lib/resources.ts
+++ b/src/lib/resources.ts
@@ -40,7 +40,7 @@ export class Vaults extends OPResource {
      public async listVaultsByTitle(title: string): Promise<Vault[]> {
         const { data } = await this.adapter.sendRequest(
             "get",
-            `${this.basePath}?${QueryBuilder.filterByTitle(title)}`,
+            `${this.basePath}/?${QueryBuilder.filterByTitle(title)}`,
         );
 
         return ObjectSerializer.deserialize(data, "Array<Vault>");
@@ -262,7 +262,7 @@ export class Items extends OPResource {
         return this.getById(item.vault.id, item.id);
     }
 
-    private async getSimpleItemByTitle(vaultId: string, title: string): Promise<SimpleItem> {
+    public async getSimpleItemByTitle(vaultId: string, title: string): Promise<SimpleItem> {
         const queryPath = `${this.basePath(
             vaultId,
         )}?${QueryBuilder.filterByTitle(title)}`;
@@ -278,22 +278,6 @@ export class Items extends OPResource {
         }
 
         return ObjectSerializer.deserialize(data[0], "Item");
-    }
-
-    /**
-     * Get a list of files an Item contains.
-     *
-     * @param {string} vaultId
-     * @param {string} itemId
-     * @returns {Promise<ItemFile[]>}
-     */
-    public async listFiles(vaultId: string, itemId: string): Promise<ItemFile[]> {
-        const { data } = await this.adapter.sendRequest(
-            "get",
-            `${this.basePath(vaultId, itemId)}/files`
-        );
-
-        return ObjectSerializer.deserialize(data, "Array<ItemFile>");
     }
 
 
@@ -331,6 +315,20 @@ export class Files extends OPResource {
     }
 
     /**
+     * Get a list of files an Item contains.
+     *
+     * @param {string} vaultQuery - the Vaults's title or ID
+     * @param {string} itemQuery  - the Item's title or ID
+     * @returns {Promise<ItemFile[]>}
+     */
+     public async listFiles(vaultQuery: string, itemQuery: string): Promise<ItemFile[]> {
+        const url = await this.generateFilesUrl(vaultQuery, itemQuery);
+        const { data } = await this.adapter.sendRequest("get", url);
+
+        return ObjectSerializer.deserialize(data, "Array<ItemFile>");
+    }
+
+    /**
      * Get an Item's specific File with a matching ID value.
      *
      * @param {string} vaultQuery - the Vaults's title or ID
@@ -340,25 +338,41 @@ export class Files extends OPResource {
      * @private
      */
      async getById(vaultQuery: string, itemQuery: string, fileId: string): Promise<ItemFile> {
-        const url = await this.generateFileUrl(vaultQuery, itemQuery, fileId);
+        const url = await this.generateSingleFileUrl(vaultQuery, itemQuery, fileId);
         const { data } = await this.adapter.sendRequest("get", url);
 
         return ObjectSerializer.deserialize(data, "ItemFile");
     }
 
-    private async generateFileUrl(vaultQuery: string, itemQuery: string, fileId: string): Promise<string> {
+    private async generateFilesUrl(vaultQuery: string, itemQuery: string): Promise<string> {
         let url = "v1/vaults";
-        const vaultId = await this.returnResourceId<Vault>(vaultQuery, this.vaults.getVaultByTitle);
-        const itemId = await this.returnResourceId<Item>(itemQuery, this.items.getByTitle);
-        url += `/${vaultId}/${itemId}/${fileId}`;
+        const vaultId = await this.vaultIdFromQuery(vaultQuery);
+        const itemId = await this.itemIdFromQuery(vaultId, itemQuery);
+        url += `/${vaultId}/items/${itemId}/files/`;
 
         return url;
     }
 
-    private async returnResourceId<T>(query: string, fetchByTitleFunc: (...params) => Promise<T>): Promise<string> {
+    private async generateSingleFileUrl(vaultQuery: string, itemQuery: string, fileId: string): Promise<string> {
+        let url = await this.generateFilesUrl(vaultQuery, itemQuery);
+        url += fileId;
+
+        return url;
+    }
+
+    private async vaultIdFromQuery(query: string): Promise<string> {
         if (!isValidId(query)) {
-            const resource: T = await fetchByTitleFunc(query);
-            return resource['id'];
+            const vault: Vault = await this.vaults.getVaultByTitle(query);
+            return vault.id;
+        }
+
+        return query;
+    }
+
+    private async itemIdFromQuery(vaultId: string, query: string): Promise<string> {
+        if (!isValidId(query)) {
+            const item: Item = await this.items.getSimpleItemByTitle(vaultId, query);
+            return item.id;
         }
 
         return query;

--- a/src/lib/utils/error.ts
+++ b/src/lib/utils/error.ts
@@ -39,4 +39,8 @@ export class ErrorMessageFactory {
     static noOTPFoundForItem(itemId = ""): string {
         return `${ERROR_MESSAGE.NO_OTP_FOR_THE_ITEM} ${itemId}`;
     }
+
+    static noFileIdProvided(): string {
+        return ERROR_MESSAGE.NO_FILE_ID_PROVIDED;
+    }
 }


### PR DESCRIPTION
Resolves #63 

The changes are done in this PR.

1. Add new `getFileById` method to `op` client.
2. `getFileById` can be used with `vault/item` ids or with titles.
3. Created `Files` class that handles all the operation on files.
4. Moved `listFiles` method from `Items` class to the new `Files` class.
5. `listFiles` can be used with `vault/item` ids or with titles.
6. Additional unit tests.
7. Refactoring in `ApiMock` class.