### PR TITLE
Remove unused packages from devDependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -30,8 +30,6 @@
                 "eslint-plugin-jsdoc": "^46.9.0",
                 "eslint-plugin-no-unsanitized": "^4.0.2",
                 "eslint-plugin-prefer-arrow": "^1.2.3",
-                "eslint-plugin-react": "^7.33.2",
-                "eslint-plugin-react-hooks": "^4.6.0",
                 "eslint-plugin-unicorn": "^49.0.0",
                 "jest": "^29.7.0",
                 "nock": "^13.3.8",
@@ -1940,19 +1938,6 @@
                 "url": "https://github.com/sponsors/ljharb"
             }
         },
-        "node_modules/array.prototype.tosorted": {
-            "version": "1.1.2",
-            "resolved": "https://registry.npmjs.org/array.prototype.tosorted/-/array.prototype.tosorted-1.1.2.tgz",
-            "integrity": "sha512-HuQCHOlk1Weat5jzStICBCd83NxiIMwqDg/dHEsoefabn/hJRj5pVdWcPUSpRrwhwxZOsQassMpgN/xRYFBMIg==",
-            "dev": true,
-            "dependencies": {
-                "call-bind": "^1.0.2",
-                "define-properties": "^1.2.0",
-                "es-abstract": "^1.22.1",
-                "es-shim-unscopables": "^1.0.0",
-                "get-intrinsic": "^1.2.1"
-            }
-        },
         "node_modules/arraybuffer.prototype.slice": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/arraybuffer.prototype.slice/-/arraybuffer.prototype.slice-1.0.2.tgz",
@@ -1972,15 +1957,6 @@
             },
             "funding": {
                 "url": "https://github.com/sponsors/ljharb"
-            }
-        },
-        "node_modules/asynciterator.prototype": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/asynciterator.prototype/-/asynciterator.prototype-1.0.0.tgz",
-            "integrity": "sha512-wwHYEIS0Q80f5mosx3L/dfG5t5rjEa9Ft51GTaNt862EnpyGHpgz2RkZvLPp1oF5TnAiTohkEKVEu8pQPJI7Vg==",
-            "dev": true,
-            "dependencies": {
-                "has-symbols": "^1.0.3"
             }
         },
         "node_modules/asynckit": {
@@ -2691,28 +2667,6 @@
                 "url": "https://github.com/sponsors/ljharb"
             }
         },
-        "node_modules/es-iterator-helpers": {
-            "version": "1.0.15",
-            "resolved": "https://registry.npmjs.org/es-iterator-helpers/-/es-iterator-helpers-1.0.15.tgz",
-            "integrity": "sha512-GhoY8uYqd6iwUl2kgjTm4CZAf6oo5mHK7BPqx3rKgx893YSsy0LGHV6gfqqQvZt/8xM8xeOnfXBCfqclMKkJ5g==",
-            "dev": true,
-            "dependencies": {
-                "asynciterator.prototype": "^1.0.0",
-                "call-bind": "^1.0.2",
-                "define-properties": "^1.2.1",
-                "es-abstract": "^1.22.1",
-                "es-set-tostringtag": "^2.0.1",
-                "function-bind": "^1.1.1",
-                "get-intrinsic": "^1.2.1",
-                "globalthis": "^1.0.3",
-                "has-property-descriptors": "^1.0.0",
-                "has-proto": "^1.0.1",
-                "has-symbols": "^1.0.3",
-                "internal-slot": "^1.0.5",
-                "iterator.prototype": "^1.1.2",
-                "safe-array-concat": "^1.0.1"
-            }
-        },
         "node_modules/es-set-tostringtag": {
             "version": "2.0.2",
             "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.0.2.tgz",
@@ -3002,86 +2956,6 @@
             "dev": true,
             "peerDependencies": {
                 "eslint": ">=2.0.0"
-            }
-        },
-        "node_modules/eslint-plugin-react": {
-            "version": "7.33.2",
-            "resolved": "https://registry.npmjs.org/eslint-plugin-react/-/eslint-plugin-react-7.33.2.tgz",
-            "integrity": "sha512-73QQMKALArI8/7xGLNI/3LylrEYrlKZSb5C9+q3OtOewTnMQi5cT+aE9E41sLCmli3I9PGGmD1yiZydyo4FEPw==",
-            "dev": true,
-            "dependencies": {
-                "array-includes": "^3.1.6",
-                "array.prototype.flatmap": "^1.3.1",
-                "array.prototype.tosorted": "^1.1.1",
-                "doctrine": "^2.1.0",
-                "es-iterator-helpers": "^1.0.12",
-                "estraverse": "^5.3.0",
-                "jsx-ast-utils": "^2.4.1 || ^3.0.0",
-                "minimatch": "^3.1.2",
-                "object.entries": "^1.1.6",
-                "object.fromentries": "^2.0.6",
-                "object.hasown": "^1.1.2",
-                "object.values": "^1.1.6",
-                "prop-types": "^15.8.1",
-                "resolve": "^2.0.0-next.4",
-                "semver": "^6.3.1",
-                "string.prototype.matchall": "^4.0.8"
-            },
-            "engines": {
-                "node": ">=4"
-            },
-            "peerDependencies": {
-                "eslint": "^3 || ^4 || ^5 || ^6 || ^7 || ^8"
-            }
-        },
-        "node_modules/eslint-plugin-react-hooks": {
-            "version": "4.6.0",
-            "resolved": "https://registry.npmjs.org/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-4.6.0.tgz",
-            "integrity": "sha512-oFc7Itz9Qxh2x4gNHStv3BqJq54ExXmfC+a1NjAta66IAN87Wu0R/QArgIS9qKzX3dXKPI9H5crl9QchNMY9+g==",
-            "dev": true,
-            "engines": {
-                "node": ">=10"
-            },
-            "peerDependencies": {
-                "eslint": "^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0-0"
-            }
-        },
-        "node_modules/eslint-plugin-react/node_modules/doctrine": {
-            "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-2.1.0.tgz",
-            "integrity": "sha512-35mSku4ZXK0vfCuHEDAwt55dg2jNajHZ1odvF+8SSr82EsZY4QmXfuWso8oEd8zRhVObSN18aM0CjSdoBX7zIw==",
-            "dev": true,
-            "dependencies": {
-                "esutils": "^2.0.2"
-            },
-            "engines": {
-                "node": ">=0.10.0"
-            }
-        },
-        "node_modules/eslint-plugin-react/node_modules/resolve": {
-            "version": "2.0.0-next.5",
-            "resolved": "https://registry.npmjs.org/resolve/-/resolve-2.0.0-next.5.tgz",
-            "integrity": "sha512-U7WjGVG9sH8tvjW5SmGbQuui75FiyjAX72HX15DwBBwF9dNiQZRQAg9nnPhYy+TUnE0+VcrttuvNI8oSxZcocA==",
-            "dev": true,
-            "dependencies": {
-                "is-core-module": "^2.13.0",
-                "path-parse": "^1.0.7",
-                "supports-preserve-symlinks-flag": "^1.0.0"
-            },
-            "bin": {
-                "resolve": "bin/resolve"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/ljharb"
-            }
-        },
-        "node_modules/eslint-plugin-react/node_modules/semver": {
-            "version": "6.3.1",
-            "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
-            "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
-            "dev": true,
-            "bin": {
-                "semver": "bin/semver.js"
             }
         },
         "node_modules/eslint-plugin-unicorn": {
@@ -3943,21 +3817,6 @@
             "integrity": "sha512-zz06S8t0ozoDXMG+ube26zeCTNXcKIPJZJi8hBrF4idCLms4CG9QtK7qBl1boi5ODzFpjswb5JPmHCbMpjaYzg==",
             "dev": true
         },
-        "node_modules/is-async-function": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/is-async-function/-/is-async-function-2.0.0.tgz",
-            "integrity": "sha512-Y1JXKrfykRJGdlDwdKlLpLyMIiWqWvuSd17TvZk68PLAOGOoF4Xyav1z0Xhoi+gCYjZVeC5SI+hYFOfvXmGRCA==",
-            "dev": true,
-            "dependencies": {
-                "has-tostringtag": "^1.0.0"
-            },
-            "engines": {
-                "node": ">= 0.4"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/ljharb"
-            }
-        },
         "node_modules/is-bigint": {
             "version": "1.0.4",
             "resolved": "https://registry.npmjs.org/is-bigint/-/is-bigint-1.0.4.tgz",
@@ -4049,18 +3908,6 @@
                 "node": ">=0.10.0"
             }
         },
-        "node_modules/is-finalizationregistry": {
-            "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/is-finalizationregistry/-/is-finalizationregistry-1.0.2.tgz",
-            "integrity": "sha512-0by5vtUJs8iFQb5TYUHHPudOR+qXYIMKtiUzvLIZITZUjknFmziyBJuLhVRc+Ds0dREFlskDNJKYIdIzu/9pfw==",
-            "dev": true,
-            "dependencies": {
-                "call-bind": "^1.0.2"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/ljharb"
-            }
-        },
         "node_modules/is-fullwidth-code-point": {
             "version": "3.0.0",
             "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
@@ -4079,21 +3926,6 @@
                 "node": ">=6"
             }
         },
-        "node_modules/is-generator-function": {
-            "version": "1.0.10",
-            "resolved": "https://registry.npmjs.org/is-generator-function/-/is-generator-function-1.0.10.tgz",
-            "integrity": "sha512-jsEjy9l3yiXEQ+PsXdmBwEPcOxaXWLspKdplFUVI9vq1iZgIekeC0L167qeu86czQaxed3q/Uzuw0swL0irL8A==",
-            "dev": true,
-            "dependencies": {
-                "has-tostringtag": "^1.0.0"
-            },
-            "engines": {
-                "node": ">= 0.4"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/ljharb"
-            }
-        },
         "node_modules/is-glob": {
             "version": "4.0.3",
             "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
@@ -4104,15 +3936,6 @@
             },
             "engines": {
                 "node": ">=0.10.0"
-            }
-        },
-        "node_modules/is-map": {
-            "version": "2.0.2",
-            "resolved": "https://registry.npmjs.org/is-map/-/is-map-2.0.2.tgz",
-            "integrity": "sha512-cOZFQQozTha1f4MxLFzlgKYPTyj26picdZTx82hbc/Xf4K/tZOOXSCkMvU4pKioRXGDLJRn0GM7Upe7kR721yg==",
-            "dev": true,
-            "funding": {
-                "url": "https://github.com/sponsors/ljharb"
             }
         },
         "node_modules/is-negative-zero": {
@@ -4172,15 +3995,6 @@
             "engines": {
                 "node": ">= 0.4"
             },
-            "funding": {
-                "url": "https://github.com/sponsors/ljharb"
-            }
-        },
-        "node_modules/is-set": {
-            "version": "2.0.2",
-            "resolved": "https://registry.npmjs.org/is-set/-/is-set-2.0.2.tgz",
-            "integrity": "sha512-+2cnTEZeY5z/iXGbLhPrOAaK/Mau5k5eXq9j14CpRTftq0pAJu2MwVRSZhyZWBzx3o6X795Lz6Bpb6R0GKf37g==",
-            "dev": true,
             "funding": {
                 "url": "https://github.com/sponsors/ljharb"
             }
@@ -4254,15 +4068,6 @@
                 "url": "https://github.com/sponsors/ljharb"
             }
         },
-        "node_modules/is-weakmap": {
-            "version": "2.0.1",
-            "resolved": "https://registry.npmjs.org/is-weakmap/-/is-weakmap-2.0.1.tgz",
-            "integrity": "sha512-NSBR4kH5oVj1Uwvv970ruUkCV7O1mzgVFO4/rev2cLRda9Tm9HrL70ZPut4rOHgY0FNrUu9BCbXA2sdQ+x0chA==",
-            "dev": true,
-            "funding": {
-                "url": "https://github.com/sponsors/ljharb"
-            }
-        },
         "node_modules/is-weakref": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/is-weakref/-/is-weakref-1.0.2.tgz",
@@ -4270,19 +4075,6 @@
             "dev": true,
             "dependencies": {
                 "call-bind": "^1.0.2"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/ljharb"
-            }
-        },
-        "node_modules/is-weakset": {
-            "version": "2.0.2",
-            "resolved": "https://registry.npmjs.org/is-weakset/-/is-weakset-2.0.2.tgz",
-            "integrity": "sha512-t2yVvttHkQktwnNNmBQ98AhENLdPUTDTE21uPqAQ0ARwQfGeQKRVS0NNurH7bTf7RrvcVn1OOge45CnBeHCSmg==",
-            "dev": true,
-            "dependencies": {
-                "call-bind": "^1.0.2",
-                "get-intrinsic": "^1.1.1"
             },
             "funding": {
                 "url": "https://github.com/sponsors/ljharb"
@@ -4364,19 +4156,6 @@
             },
             "engines": {
                 "node": ">=8"
-            }
-        },
-        "node_modules/iterator.prototype": {
-            "version": "1.1.2",
-            "resolved": "https://registry.npmjs.org/iterator.prototype/-/iterator.prototype-1.1.2.tgz",
-            "integrity": "sha512-DR33HMMr8EzwuRL8Y9D3u2BMj8+RqSE850jfGu59kS7tbmPLzGkZmVSfyCFSDxuZiEY6Rzt3T2NA/qU+NwVj1w==",
-            "dev": true,
-            "dependencies": {
-                "define-properties": "^1.2.1",
-                "get-intrinsic": "^1.2.1",
-                "has-symbols": "^1.0.3",
-                "reflect.getprototypeof": "^1.0.4",
-                "set-function-name": "^2.0.1"
             }
         },
         "node_modules/jest": {
@@ -5016,21 +4795,6 @@
                 "node": ">=6"
             }
         },
-        "node_modules/jsx-ast-utils": {
-            "version": "3.3.5",
-            "resolved": "https://registry.npmjs.org/jsx-ast-utils/-/jsx-ast-utils-3.3.5.tgz",
-            "integrity": "sha512-ZZow9HBI5O6EPgSJLUb8n2NKgmVWTwCvHGwFuJlMjvLFqlGG6pjirPhtdsseaLZjSibD8eegzmYpUZwoIlj2cQ==",
-            "dev": true,
-            "dependencies": {
-                "array-includes": "^3.1.6",
-                "array.prototype.flat": "^1.3.1",
-                "object.assign": "^4.1.4",
-                "object.values": "^1.1.6"
-            },
-            "engines": {
-                "node": ">=4.0"
-            }
-        },
         "node_modules/keyv": {
             "version": "4.5.4",
             "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.4.tgz",
@@ -5108,18 +4872,6 @@
             "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
             "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
             "dev": true
-        },
-        "node_modules/loose-envify": {
-            "version": "1.4.0",
-            "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
-            "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
-            "dev": true,
-            "dependencies": {
-                "js-tokens": "^3.0.0 || ^4.0.0"
-            },
-            "bin": {
-                "loose-envify": "cli.js"
-            }
         },
         "node_modules/lru-cache": {
             "version": "5.1.1",
@@ -5345,15 +5097,6 @@
                 "node": ">=8"
             }
         },
-        "node_modules/object-assign": {
-            "version": "4.1.1",
-            "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
-            "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
-            "dev": true,
-            "engines": {
-                "node": ">=0.10.0"
-            }
-        },
         "node_modules/object-inspect": {
             "version": "1.13.1",
             "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.1.tgz",
@@ -5390,20 +5133,6 @@
                 "url": "https://github.com/sponsors/ljharb"
             }
         },
-        "node_modules/object.entries": {
-            "version": "1.1.7",
-            "resolved": "https://registry.npmjs.org/object.entries/-/object.entries-1.1.7.tgz",
-            "integrity": "sha512-jCBs/0plmPsOnrKAfFQXRG2NFjlhZgjjcBLSmTnEhU8U6vVTsVe8ANeQJCHTl3gSsI4J+0emOoCgoKlmQPMgmA==",
-            "dev": true,
-            "dependencies": {
-                "call-bind": "^1.0.2",
-                "define-properties": "^1.2.0",
-                "es-abstract": "^1.22.1"
-            },
-            "engines": {
-                "node": ">= 0.4"
-            }
-        },
         "node_modules/object.fromentries": {
             "version": "2.0.7",
             "resolved": "https://registry.npmjs.org/object.fromentries/-/object.fromentries-2.0.7.tgz",
@@ -5431,19 +5160,6 @@
                 "define-properties": "^1.2.0",
                 "es-abstract": "^1.22.1",
                 "get-intrinsic": "^1.2.1"
-            }
-        },
-        "node_modules/object.hasown": {
-            "version": "1.1.3",
-            "resolved": "https://registry.npmjs.org/object.hasown/-/object.hasown-1.1.3.tgz",
-            "integrity": "sha512-fFI4VcYpRHvSLXxP7yiZOMAd331cPfd2p7PFDVbgUsYOfCT3tICVqXWngbjr4m49OvsBwUBQ6O2uQoJvy3RexA==",
-            "dev": true,
-            "dependencies": {
-                "define-properties": "^1.2.0",
-                "es-abstract": "^1.22.1"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/ljharb"
             }
         },
         "node_modules/object.values": {
@@ -5778,23 +5494,6 @@
                 "node": ">= 6"
             }
         },
-        "node_modules/prop-types": {
-            "version": "15.8.1",
-            "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz",
-            "integrity": "sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==",
-            "dev": true,
-            "dependencies": {
-                "loose-envify": "^1.4.0",
-                "object-assign": "^4.1.1",
-                "react-is": "^16.13.1"
-            }
-        },
-        "node_modules/prop-types/node_modules/react-is": {
-            "version": "16.13.1",
-            "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
-            "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
-            "dev": true
-        },
         "node_modules/propagate": {
             "version": "2.0.1",
             "resolved": "https://registry.npmjs.org/propagate/-/propagate-2.0.1.tgz",
@@ -5960,26 +5659,6 @@
             "dev": true,
             "engines": {
                 "node": ">=8"
-            }
-        },
-        "node_modules/reflect.getprototypeof": {
-            "version": "1.0.4",
-            "resolved": "https://registry.npmjs.org/reflect.getprototypeof/-/reflect.getprototypeof-1.0.4.tgz",
-            "integrity": "sha512-ECkTw8TmJwW60lOTR+ZkODISW6RQ8+2CL3COqtiJKLd6MmB45hN51HprHFziKLGkAuTGQhBb91V8cy+KHlaCjw==",
-            "dev": true,
-            "dependencies": {
-                "call-bind": "^1.0.2",
-                "define-properties": "^1.2.0",
-                "es-abstract": "^1.22.1",
-                "get-intrinsic": "^1.2.1",
-                "globalthis": "^1.0.3",
-                "which-builtin-type": "^1.1.3"
-            },
-            "engines": {
-                "node": ">= 0.4"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/ljharb"
             }
         },
         "node_modules/regexp-tree": {
@@ -6412,26 +6091,6 @@
             },
             "engines": {
                 "node": ">=8"
-            }
-        },
-        "node_modules/string.prototype.matchall": {
-            "version": "4.0.10",
-            "resolved": "https://registry.npmjs.org/string.prototype.matchall/-/string.prototype.matchall-4.0.10.tgz",
-            "integrity": "sha512-rGXbGmOEosIQi6Qva94HUjgPs9vKW+dkG7Y8Q5O2OYkWL6wFaTRZO8zM4mhP94uX55wgyrXzfS2aGtGzUL7EJQ==",
-            "dev": true,
-            "dependencies": {
-                "call-bind": "^1.0.2",
-                "define-properties": "^1.2.0",
-                "es-abstract": "^1.22.1",
-                "get-intrinsic": "^1.2.1",
-                "has-symbols": "^1.0.3",
-                "internal-slot": "^1.0.5",
-                "regexp.prototype.flags": "^1.5.0",
-                "set-function-name": "^2.0.0",
-                "side-channel": "^1.0.4"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/ljharb"
             }
         },
         "node_modules/string.prototype.trim": {
@@ -7050,47 +6709,6 @@
                 "is-number-object": "^1.0.4",
                 "is-string": "^1.0.5",
                 "is-symbol": "^1.0.3"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/ljharb"
-            }
-        },
-        "node_modules/which-builtin-type": {
-            "version": "1.1.3",
-            "resolved": "https://registry.npmjs.org/which-builtin-type/-/which-builtin-type-1.1.3.tgz",
-            "integrity": "sha512-YmjsSMDBYsM1CaFiayOVT06+KJeXf0o5M/CAd4o1lTadFAtacTUM49zoYxr/oroopFDfhvN6iEcBxUyc3gvKmw==",
-            "dev": true,
-            "dependencies": {
-                "function.prototype.name": "^1.1.5",
-                "has-tostringtag": "^1.0.0",
-                "is-async-function": "^2.0.0",
-                "is-date-object": "^1.0.5",
-                "is-finalizationregistry": "^1.0.2",
-                "is-generator-function": "^1.0.10",
-                "is-regex": "^1.1.4",
-                "is-weakref": "^1.0.2",
-                "isarray": "^2.0.5",
-                "which-boxed-primitive": "^1.0.2",
-                "which-collection": "^1.0.1",
-                "which-typed-array": "^1.1.9"
-            },
-            "engines": {
-                "node": ">= 0.4"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/ljharb"
-            }
-        },
-        "node_modules/which-collection": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/which-collection/-/which-collection-1.0.1.tgz",
-            "integrity": "sha512-W8xeTUwaln8i3K/cY1nGXzdnVZlidBcagyNFtBdD5kxnb4TvGKR7FfSIS3mYpwWS1QUCutfKz8IY8RjftB0+1A==",
-            "dev": true,
-            "dependencies": {
-                "is-map": "^2.0.1",
-                "is-set": "^2.0.1",
-                "is-weakmap": "^2.0.1",
-                "is-weakset": "^2.0.1"
             },
             "funding": {
                 "url": "https://github.com/sponsors/ljharb"

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,7 +19,6 @@
                 "@types/debug": "^4.1.12",
                 "@types/jest": "^29.5.10",
                 "@types/lodash.clonedeep": "^4.5.9",
-                "@types/vfile-message": "2.0.0",
                 "@typescript-eslint/eslint-plugin": "^6.13.1",
                 "@typescript-eslint/parser": "^6.13.1",
                 "codecov": "^3.8.3",
@@ -1474,22 +1473,6 @@
             "resolved": "https://registry.npmjs.org/@types/stack-utils/-/stack-utils-2.0.3.tgz",
             "integrity": "sha512-9aEbYZ3TbYMznPdcdr3SmIrLXwC/AKZXQeCf9Pgao5CKb8CyHuEX5jzWPTkvregvhRJHcpRO6BFoGW9ycaOkYw==",
             "dev": true
-        },
-        "node_modules/@types/unist": {
-            "version": "3.0.2",
-            "resolved": "https://registry.npmjs.org/@types/unist/-/unist-3.0.2.tgz",
-            "integrity": "sha512-dqId9J8K/vGi5Zr7oo212BGii5m3q5Hxlkwy3WpYuKPklmBEvsbMYYyLxAQpSffdLl/gdW0XUpKWFvYmyoWCoQ==",
-            "dev": true
-        },
-        "node_modules/@types/vfile-message": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/@types/vfile-message/-/vfile-message-2.0.0.tgz",
-            "integrity": "sha512-GpTIuDpb9u4zIO165fUy9+fXcULdD8HFRNli04GehoMVbeNq7D6OBnqSmg3lxZnC+UvgUhEWKxdKiwYUkGltIw==",
-            "deprecated": "This is a stub types definition. vfile-message provides its own type definitions, so you do not need this installed.",
-            "dev": true,
-            "dependencies": {
-                "vfile-message": "*"
-            }
         },
         "node_modules/@types/yargs": {
             "version": "17.0.32",
@@ -6547,19 +6530,6 @@
             "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
             "dev": true
         },
-        "node_modules/unist-util-stringify-position": {
-            "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/unist-util-stringify-position/-/unist-util-stringify-position-4.0.0.tgz",
-            "integrity": "sha512-0ASV06AAoKCDkS2+xw5RXJywruurpbC4JZSm7nr7MOt1ojAzvyyaO+UxZf18j8FCF6kmzCZKcAgN/yu2gm2XgQ==",
-            "dev": true,
-            "dependencies": {
-                "@types/unist": "^3.0.0"
-            },
-            "funding": {
-                "type": "opencollective",
-                "url": "https://opencollective.com/unified"
-            }
-        },
         "node_modules/update-browserslist-db": {
             "version": "1.0.13",
             "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.0.13.tgz",
@@ -6642,20 +6612,6 @@
             "dependencies": {
                 "spdx-correct": "^3.0.0",
                 "spdx-expression-parse": "^3.0.0"
-            }
-        },
-        "node_modules/vfile-message": {
-            "version": "4.0.2",
-            "resolved": "https://registry.npmjs.org/vfile-message/-/vfile-message-4.0.2.tgz",
-            "integrity": "sha512-jRDZ1IMLttGj41KcZvlrYAaI3CfqpLpfpf+Mfig13viT6NKvRzWZ+lXz0Y5D60w6uJIBAOGq9mSHf0gktF0duw==",
-            "dev": true,
-            "dependencies": {
-                "@types/unist": "^3.0.0",
-                "unist-util-stringify-position": "^4.0.0"
-            },
-            "funding": {
-                "type": "opencollective",
-                "url": "https://opencollective.com/unified"
             }
         },
         "node_modules/walker": {

--- a/package.json
+++ b/package.json
@@ -35,8 +35,6 @@
         "eslint-plugin-jsdoc": "^46.9.0",
         "eslint-plugin-no-unsanitized": "^4.0.2",
         "eslint-plugin-prefer-arrow": "^1.2.3",
-        "eslint-plugin-react": "^7.33.2",
-        "eslint-plugin-react-hooks": "^4.6.0",
         "eslint-plugin-unicorn": "^49.0.0",
         "jest": "^29.7.0",
         "nock": "^13.3.8",

--- a/package.json
+++ b/package.json
@@ -24,7 +24,6 @@
         "@types/debug": "^4.1.12",
         "@types/jest": "^29.5.10",
         "@types/lodash.clonedeep": "^4.5.9",
-        "@types/vfile-message": "2.0.0",
         "@typescript-eslint/eslint-plugin": "^6.13.1",
         "@typescript-eslint/parser": "^6.13.1",
         "codecov": "^3.8.3",


### PR DESCRIPTION
This PR removes three unused packages from the repository's `devDependencies`. It's good practice to remove nused packages so that we don't need to update them or be concerned if they have vulnerabilities identified by `npm audit`.

- This repo does not use React, so having the `eslint-plugin-react` and `eslint-plugin-react` packages as devDependencies doesn't make sense.
  - Further to this, neither of these plugins were being referenced in the `.estlintrc.yml` file.
- When installing or updating dependencies a `vfile-message provides its own type definitions, so you don't need @types/vfile-message installed` message is logged in the terminal.
  - This repo does not use the `vfile-message` package and there are no references to `vfile` anywhere in the codebase.