### PR TITLE
export HttpError interface

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -19,3 +19,5 @@ export {
     ClientConfig,
 } from "./lib/client";
 export { ItemBuilder } from "./lib/builders";
+
+export { HttpError } from './lib/utils/error'


### PR DESCRIPTION
I need the `HttpError` interface exported to be able to use it as a a type guard and I want to keep the type information