### PR TITLE
Improve workflow permissions

### DIFF
--- a/.github/workflows/pr-check-signed-commits.yml
+++ b/.github/workflows/pr-check-signed-commits.yml
@@ -1,12 +1,14 @@
 name: Check signed commits in PR
+
 on: pull_request_target
+
+permissions:
+  contents: read
+  pull-requests: write
 
 jobs:
   build:
     name: Check signed commits in PR
-    permissions:
-      contents: read
-      pull-requests: write
     runs-on: ubuntu-latest
     steps:
       - name: Check signed commits in PR

--- a/.github/workflows/release-pr.yml
+++ b/.github/workflows/release-pr.yml
@@ -1,85 +1,89 @@
-on:
-    create:
-        branches:
-
 name: Open Release PR for review
 
+on:
+  create:
+    branches:
+
+permissions:
+  contents: read
+  pull-requests: write
+
 jobs:
-    # This job is necessary because GitHub does not (yet) support
-    # filtering `create` triggers by branch name.
-    # See: https://github.community/t/trigger-job-on-branch-created/16878/5
-    should_create_pr:
-        name: Check if PR for branch already exists
-        runs-on: ubuntu-latest
-        outputs:
-            result: ${{ steps.is_release_branch_without_pr.outputs.result }}
-        steps:
-            - id: is_release_branch_without_pr
-              name: Find matching PR
-              uses: actions/github-script@v7
-              with:
-                  github-token: ${{ secrets.GITHUB_TOKEN }}
-                  script: |
-                      // Search for an existing PR with head & base
-                      //  that match the created branch
+  # This job is necessary because GitHub does not (yet) support
+  # filtering `create` triggers by branch name.
+  # See: https://github.community/t/trigger-job-on-branch-created/16878/5
+  should_create_pr:
+    name: Check if PR for branch already exists
+    runs-on: ubuntu-latest
+    outputs:
+      result: ${{ steps.is_release_branch_without_pr.outputs.result }}
+    steps:
+      - id: is_release_branch_without_pr
+        name: Find matching PR
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            // Search for an existing PR with head & base
+            //  that match the created branch
 
-                      const [releaseBranchName] = context.ref.match("release/v[0-9]+\.[0-9]+\.[0-9]+") || []
+            const [releaseBranchName] = context.ref.match("release/v[0-9]+\.[0-9]+\.[0-9]+") || []
 
-                      if(!releaseBranchName) { return false }
+            if(!releaseBranchName) { return false }
 
-                      const {data: prs} = await github.pulls.list({
-                          ...context.repo,
-                          state: 'open',
-                          head: `1Password:${releaseBranchName}`,
-                          base: context.payload.master_branch
-                      })
+            const {data: prs} = await github.pulls.list({
+                ...context.repo,
+                state: 'open',
+                head: `1Password:${releaseBranchName}`,
+                base: context.payload.master_branch
+            })
 
-                      return prs.length === 0
+            return prs.length === 0
 
-    create_pr:
-        needs: should_create_pr
-        if: needs.should_create_pr.outputs.result == 'true'
-        name: Create Release Pull Request
-        runs-on: ubuntu-latest
-        steps:
-            - uses: actions/checkout@v4
+  create_pr:
+    needs: should_create_pr
+    if: needs.should_create_pr.outputs.result == 'true'
+    name: Create Release Pull Request
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
 
-            - name: Parse release version
-              id: get_version
-              run: echo "::set-output name=version::`echo "${GITHUB_REF}" | sed 's|^refs/heads/release/v?*||g'`"
+      - name: Parse release version
+        id: get_version
+        run: echo "::set-output name=version::`echo "${GITHUB_REF}" | sed 's|^refs/heads/release/v?*||g'`"
 
-            - name: Prepare Pull Request
-              id: prep_pr
-              run: |
-                  CHANGELOG_PATH=$(printf "%s/CHANGELOG.md" "${GITHUB_WORKSPACE}")
+      - name: Prepare Pull Request
+        id: prep_pr
+        run: |
+          CHANGELOG_PATH=$(printf "%s/CHANGELOG.md" "${GITHUB_WORKSPACE}")
 
-                  LOG_ENTRY=$(awk '/START\/v[0-9]+\.[0-9]+\.[0-9]+*/{f=1; next} /---/{if (f == 1) exit} f' "${CHANGELOG_PATH}")
-                  export PR_BODY=$(cat <<EOF
-                  This is an automated PR for a new release.
+          LOG_ENTRY=$(awk '/START\/v[0-9]+\.[0-9]+\.[0-9]+*/{f=1; next} /---/{if (f == 1) exit} f' "${CHANGELOG_PATH}")
+          export PR_BODY=$(cat <<EOF
+          This is an automated PR for a new release.
 
-                  Please check the following before approving:
-                  - [ ] Changelog is accurate. The documented changes for this release are printed below.
-                  - [ ] Any files referencing a version number. Confirm it matches the version number in the branch name.
-                  ---
-                  ## Release Changelog Preview
-                  ${LOG_ENTRY}
-                  EOF
-                  )
+          Please check the following before approving:
+          - [ ] Changelog is accurate. The documented changes for this release are printed below.
+          - [ ] Any files referencing a version number. Confirm it matches the version number in the branch name.
+          ---
+          ## Release Changelog Preview
+          ${LOG_ENTRY}
+          EOF
+          )
 
-                  # Sanitizes multiline strings for action outputs (https://medium.com/agorapulse-stories/23f56447d209)
-                  PR_BODY="${PR_BODY//'%'/'%25'}"
-                  PR_BODY="${PR_BODY//$'\n'/'%0A'}"
-                  PR_BODY="${PR_BODY//$'\r'/'%0D'}"
-                  echo "::set-output name=pr_body::$(echo "$PR_BODY")"
+          # Sanitizes multiline strings for action outputs (https://medium.com/agorapulse-stories/23f56447d209)
+          PR_BODY="${PR_BODY//'%'/'%25'}"
+          PR_BODY="${PR_BODY//$'\n'/'%0A'}"
+          PR_BODY="${PR_BODY//$'\r'/'%0D'}"
+          echo "::set-output name=pr_body::$(echo "$PR_BODY")"
 
-            - name: Create Pull Request via API
-              id: post_pr
-              uses: octokit/request-action@v2.x
-              with:
-                  route: POST /repos/${{ github.repository }}/pulls
-                  title: ${{ format('Prepare Release - v{0}', steps.get_version.outputs.version) }}
-                  head: ${{ github.ref }}
-                  base: ${{ github.event.master_branch }}
-                  body: ${{ toJson(steps.prep_pr.outputs.pr_body) }}
-              env:
-                  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Create Pull Request via API
+        id: post_pr
+        uses: octokit/request-action@v2.x
+        with:
+          route: POST /repos/${{ github.repository }}/pulls
+          title: ${{ format('Prepare Release - v{0}', steps.get_version.outputs.version) }}
+          head: ${{ github.ref }}
+          base: ${{ github.event.master_branch }}
+          body: ${{ toJson(steps.prep_pr.outputs.pr_body) }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,6 +7,9 @@ on:
     types:
       - closed
 
+permissions:
+  contents: write
+
 jobs:
   release:
     runs-on: ubuntu-latest
@@ -19,8 +22,8 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v4
         with:
-          node-version: '20.x'
-          registry-url: 'https://registry.npmjs.org'
+          node-version: "20.x"
+          registry-url: "https://registry.npmjs.org"
       - run: npm install
       - name: Publish to npm
         run: npm publish

--- a/.github/workflows/test-main.yml
+++ b/.github/workflows/test-main.yml
@@ -1,30 +1,33 @@
 name: Code Coverage main
 
 on:
-    push:
-        branches:
-            - main
+  push:
+    branches:
+      - main
+
+permissions:
+  contents: read
 
 jobs:
-    coverage:
-        runs-on: ubuntu-latest
-        steps:
-            - uses: actions/checkout@v4
-            - name: Test with Node.js Latest LTS
-              uses: actions/setup-node@v4
-              with:
-                # Latest LTS version
-                node-version: '20.x'
-            - name: Cache NPM modules
-              uses: actions/cache@v3
-              with:
-                path: ~/.npm
-                key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
-                restore-keys: |
-                    ${{ runner.os }}-node-
-            - name: Run tests
-              run: npm install && npm run test:coverage
-            - name: Upload coverage to Codecov
-              uses: codecov/codecov-action@v3
-              with:
-                directory: ./coverage/
+  coverage:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Test with Node.js Latest LTS
+        uses: actions/setup-node@v4
+        with:
+          # Latest LTS version
+          node-version: "20.x"
+      - name: Cache NPM modules
+        uses: actions/cache@v3
+        with:
+          path: ~/.npm
+          key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
+          restore-keys: |
+            ${{ runner.os }}-node-
+      - name: Run tests
+        run: npm install && npm run test:coverage
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@v3
+        with:
+          directory: ./coverage/

--- a/.github/workflows/test-prs.yml
+++ b/.github/workflows/test-prs.yml
@@ -1,30 +1,33 @@
 name: Pull Request QA
 
 on:
-    pull_request:
-        types: [opened, synchronize, reopened]
+  pull_request:
+    types: [opened, synchronize, reopened]
+
+permissions:
+  contents: read
 
 jobs:
-    lintAndTestWithCoverage:
-        runs-on: ubuntu-latest
-        steps:
-            - uses: actions/checkout@v4
-            - name: Test with Node.js Latest LTS
-              uses: actions/setup-node@v4
-              with:
-                  # Latest LTS version
-                  node-version: '20.x'
-            - name: Cache NPM modules
-              uses: actions/cache@v3
-              with:
-                path: ~/.npm
-                key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
-                restore-keys: |
-                  ${{ runner.os }}-node-
-            - run: npm install
-            - run: npm run lint
-            - run: npm run test:coverage
-            - name: Upload coverage to Codecov
-              uses: codecov/codecov-action@v3
-              with:
-                directory: ./coverage/
+  lintAndTestWithCoverage:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Test with Node.js Latest LTS
+        uses: actions/setup-node@v4
+        with:
+          # Latest LTS version
+          node-version: "20.x"
+      - name: Cache NPM modules
+        uses: actions/cache@v3
+        with:
+          path: ~/.npm
+          key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
+          restore-keys: |
+            ${{ runner.os }}-node-
+      - run: npm install
+      - run: npm run lint
+      - run: npm run test:coverage
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@v3
+        with:
+          directory: ./coverage/


### PR DESCRIPTION
## Summary

This PR explicitly states the permissions needed for each of the repo's workflows. 

## Thought process

Since our project has been created before February 2023, we have the more permissive permission `write-all` set for the `GITHUB_TOKEN` used by the workflow. Therefore, to apply the principle of least privilege, we now explicitly specify the permisisons needed for each workflow (also mentioned in the Code scan alerts).

Here's how the permissions for each workflow has been determined:
- `pr-check-signed-commits` - Adds a comment in the open PR. For this it needs `contents: read` and `pull_requests: write`.
- `release` - It builds, publishes to PyPi, creates a new tag and makes a new release on GitHub with the new tag. Since the workflow makes changes to the repo, it needs `contents: write`.
- `release-pr` - It creates a PR if there's not one already for a branch with a specific format. For that it needs `contents: read` (it doesn't make changes to the branch) and `pull_requests: write`.
- `test-main` - since it's a test workflow it only needs `contents:read`.
- `test-prs` - since it's a test workflow it only needs `contents:read`.

This addressed the following Code scan security alerts:
- https://github.com/1Password/connect-sdk-js/security/code-scanning/5
- https://github.com/1Password/connect-sdk-js/security/code-scanning/4
- https://github.com/1Password/connect-sdk-js/security/code-scanning/3
- https://github.com/1Password/connect-sdk-js/security/code-scanning/2
- https://github.com/1Password/connect-sdk-js/security/code-scanning/1

In addition, I've applied the same styling format for all current workflows for consistency.