### PR TITLE
Fix open release pr job

### DIFF
--- a/.github/workflows/release-pr.yml
+++ b/.github/workflows/release-pr.yml
@@ -31,7 +31,7 @@ jobs:
 
             if(!releaseBranchName) { return false }
 
-            const {data: prs} = await github.pulls.list({
+            const {data: prs} = await github.rest.pulls.list({
                 ...context.repo,
                 state: 'open',
                 head: `1Password:${releaseBranchName}`,


### PR DESCRIPTION
Open release PR job failed recently ([logs](https://github.com/1Password/connect-sdk-js/actions/runs/16349868283))

In the latest version of github action github-script, the syntax changed and now required to use `github.rest` to access pull requests. ([docs](https://octokit.github.io/rest.js/v22/#pulls))