### PR TITLE
Bump axios to ^1.16.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
             "version": "1.4.2",
             "license": "MIT",
             "dependencies": {
-                "axios": "^1.10.0",
+                "axios": "^1.16.1",
                 "debug": "^4.4.1",
                 "lodash.clonedeep": "^4.5.0",
                 "slugify": "^1.6.6",

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
         "typescript": "^5.8.3"
     },
     "dependencies": {
-        "axios": "^1.10.0",
+        "axios": "^1.16.1",
         "debug": "^4.4.1",
         "lodash.clonedeep": "^4.5.0",
         "slugify": "^1.6.6",


### PR DESCRIPTION
## Summary
- Bumps `axios` dependency from `^1.10.0` to `^1.16.1`.
- Updates `package-lock.json` to resolve `axios@1.16.1`.

## Motivation
Addresses https://github.com/mcmarkj/1password-actions/issues/460 — downstream consumers of this SDK are pulling in an older axios via transitive dependency, and bumping here lets them resolve to a patched version.

## Test plan
- [ ] CI passes (build + lint + tests)
- [ ] No breaking changes in axios 1.10 → 1.16 affect SDK request/response handling

🤖 Generated with [Claude Code](https://claude.com/claude-code)